### PR TITLE
Prevent that a timeout occurs when succesfull

### DIFF
--- a/lib/push-notifications.js
+++ b/lib/push-notifications.js
@@ -115,6 +115,12 @@ PushNotifications.prototype.send = function (pushId, data, callback) {
     APNConnection.pushNotification(messageAPN, regIdsAPN);
 
     parallel.add(function (done) {
+      apnConnection.on('completed', function () {
+        done({
+          device: 'ios',
+          message: 'completed'
+        });
+      });      
       apnConnection.on('error', function () {
         done({
           device: 'ios',


### PR DESCRIPTION
Now, even when a push notifications is succesfully sent, a timeout occurs. This change prevents that.