### PR TITLE
Added gcm setting for phonegap compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,21 @@ In that way, they can be accessed in android in the following two ways:
     title = title != null ? title : extras.getString("gcm.notification.title");
 ```
 
+### PhoneGap compatibility mode
+
+In case your app is written with Cordova / Ionic and you are using the [PhoneGap PushPlugin](https://github.com/phonegap/phonegap-plugin-push/), 
+you can use the `phonegap` setting in order to adapt to the recommended behaviour described in 
+[https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#android-behaviour](https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#android-behaviour).
+
+```js
+    const settings = {
+        gcm: {
+            id: '<yourId>',
+            phonegap: true
+        }
+    }
+```
+
 ## APN
 
 The following parameters are used to create an APN message:

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -48,7 +48,22 @@ module.exports = (regIds, data, settings) => {
     delete opts.id;
     const GCMSender = new gcm.Sender(id, opts);
     const promises = [];
+    const notification = {
+        title: data.title, // Android, iOS (Watch)
+        body: data.body, // Android, iOS
+        icon: data.icon, // Android
+        sound: data.sound, // Android, iOS
+        badge: data.badge, // iOS
+        tag: data.tag, // Android
+        color: data.color, // Android
+        click_action: data.clickAction || data.category, // Android, iOS
+        body_loc_key: data.locKey, // Android, iOS
+        body_loc_args: data.locArgs, // Android, iOS
+        title_loc_key: data.titleLocKey, // Android, iOS
+        title_loc_args: data.titleLocArgs, // Android, iOS
+    };
     let custom = typeof data.custom === 'string' ? { message: data.custom } : {};
+
     if (typeof data.custom === 'string') {
         custom = {
             message: data.custom,
@@ -75,21 +90,8 @@ module.exports = (regIds, data, settings) => {
         timeToLive: data.expiry - Math.floor(Date.now() / 1000) || data.timeToLive || 28 * 86400,
         restrictedPackageName: data.restrictedPackageName,
         dryRun: data.dryRun || false,
-        data: custom,
-        notification: {
-            title: data.title, // Android, iOS (Watch)
-            body: data.body, // Android, iOS
-            icon: data.icon, // Android
-            sound: data.sound, // Android, iOS
-            badge: data.badge, // iOS
-            tag: data.tag, // Android
-            color: data.color, // Android
-            click_action: data.clickAction || data.category, // Android, iOS
-            body_loc_key: data.locKey, // Android, iOS
-            body_loc_args: data.locArgs, // Android, iOS
-            title_loc_key: data.titleLocKey, // Android, iOS
-            title_loc_args: data.titleLocArgs, // Android, iOS
-        },
+        data: opts.phonegap === true ? Object.assign(custom, notification) : custom, // See https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#android-behaviour
+        notification: opts.phonegap === true ? undefined : notification,
     });
     let chunk = 0;
 

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -82,9 +82,9 @@ module.exports = (regIds, data, settings) => {
     custom.icon = custom.icon || data.icon || undefined;
     custom.msgcnt = custom.msgcnt || data.badge || undefined;
     if (opts.phonegap === true) {
-        custom['content-available'] = 1
+        custom['content-available'] = 1;
     }
-    
+
     const message = new gcm.Message({ // See https://developers.google.com/cloud-messaging/http-server-ref#table5
         collapseKey: data.collapseKey,
         priority: data.priority,

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -81,7 +81,10 @@ module.exports = (regIds, data, settings) => {
     custom.sound = custom.sound || data.sound || undefined;
     custom.icon = custom.icon || data.icon || undefined;
     custom.msgcnt = custom.msgcnt || data.badge || undefined;
-
+    if (opts.phonegap === true) {
+        custom['content-available'] = 1
+    }
+    
     const message = new gcm.Message({ // See https://developers.google.com/cloud-messaging/http-server-ref#table5
         collapseKey: data.collapseKey,
         priority: data.priority,


### PR DESCRIPTION
When sending notifications to Android applications that are built with Cordova and the PhoneGap PushPlugin, the background notification handler in the app is not called.

According to the documentation of the Push Plugin (https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#android-behaviour), they recommend sending only a `data` object as payload.

In this PR I added a flag that can be used to send GCM messages in the way recommended for the PhoneGap Push plugin