### PR TITLE
Fixes appfeel/node-pushnotifications#29

### DIFF
--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -77,7 +77,7 @@ module.exports = (regIds, data, settings) => {
     }
 
     custom.title = custom.title || data.title || '';
-    custom.message = custom.message || data.body || '';
+    custom.text = custom.text || data.body || '';
     custom.sound = custom.sound || data.sound || undefined;
     custom.icon = custom.icon || data.icon || undefined;
     custom.msgcnt = custom.msgcnt || data.badge || undefined;


### PR DESCRIPTION
GCM accepts the 'text' parameter, not the 'body' parameter.