### PR TITLE
Letting send silent pushes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-pushnotifications",
   "description": "A cross-platform push service for node.js",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "author": {
     "name": "AppFeel",
     "email": "info@appfeel.com"

--- a/src/sendAPN.js
+++ b/src/sendAPN.js
@@ -30,7 +30,7 @@ module.exports = (regIds, data, settings) => {
         mutableContent: data.mutableContent || 0,
     });
     if (data.sound) {
-        message.sound = data.sound;   
+        message.sound = data.sound;
     }
     const connection = new apn.Provider(settings.apn);
 

--- a/src/sendAPN.js
+++ b/src/sendAPN.js
@@ -10,7 +10,6 @@ module.exports = (regIds, data, settings) => {
         encoding: data.encoding,
         payload: data.custom || {},
         badge: data.badge,
-        sound: data.sound || 'ping.aiff',
         alert: data.alert || {
             title: data.title,
             body: data.body,
@@ -30,6 +29,9 @@ module.exports = (regIds, data, settings) => {
         collapseId: data.collapseKey,
         mutableContent: data.mutableContent || 0,
     });
+    if (data.sound) {
+        message.sound = data.sound;   
+    }
     const connection = new apn.Provider(settings.apn);
 
     return connection.send(message, regIds)

--- a/test/send/sendAPN.js
+++ b/test/send/sendAPN.js
@@ -33,7 +33,6 @@ function sendOkMethod() {
         expect(_regIds).to.be.instanceOf(Array);
         _regIds.forEach(regId => expect(regIds).to.include(regId));
         expect(message).to.be.instanceOf(apn.Notification);
-        expect(message).to.have.deep.property('aps.sound', data.sound);
         expect(message).to.have.deep.property('aps.alert.title', data.title);
         expect(message).to.have.deep.property('aps.alert.body', data.body);
         expect(message).to.have.deep.property('payload', data.custom);
@@ -140,7 +139,6 @@ describe('push-notifications-apn', () => {
                 expect(_regIds).to.be.instanceOf(Array);
                 _regIds.forEach(regId => expect(regIds).to.include(regId));
                 expect(message).to.be.instanceOf(apn.Notification);
-                expect(message).to.have.deep.property('aps.sound', 'ping.aiff');
                 expect(message).to.have.deep.property('aps.alert.title', data.title);
                 expect(message).to.have.deep.property('aps.alert.body', data.body);
                 expect(message).to.have.deep.property('payload').deep.equal({});


### PR DESCRIPTION
I'm not able to test GCM but APNS. So, I would like to allow sending silent pushes for APNS.  Because APNS (or iOS itself) sets default push sound if the `sound` property defined. Even you set an empty string or non-existing sound in the payload for the purpose of sending silent push.