### PR TITLE
Match attach registrationToken if registration_id undefined

### DIFF
--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -16,16 +16,22 @@ const sendChunk = (GCMSender, registrationTokens, message, retries) => new Promi
                 })),
             });
         } else if (response && response.results !== undefined) {
+            var regIndex = 0;
             resolve({
                 method,
                 multicastId: response.multicast_id,
                 success: response.success,
                 failure: response.failure,
-                message: response.results.map(value => ({
+                message: response.results.map(value => {
+                    var regToken = registrationTokens[regIndex];
+                    regIndex++;
+                    return {
                     messageId: value.message_id,
-                    regId: value.registration_id,
+                    regId: value.registration_id || regToken,
                     error: value.error ? new Error(value.error) : null,
-                })),
+                    };
+                }
+                ),
             });
         } else {
             resolve({

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -16,19 +16,19 @@ const sendChunk = (GCMSender, registrationTokens, message, retries) => new Promi
                 })),
             });
         } else if (response && response.results !== undefined) {
-            var regIndex = 0;
+            let regIndex = 0;
             resolve({
                 method,
                 multicastId: response.multicast_id,
                 success: response.success,
                 failure: response.failure,
-                message: response.results.map(value => {
-                    var regToken = registrationTokens[regIndex];
-                    regIndex++;
+                message: response.results.map((value) => {
+                    const regToken = registrationTokens[regIndex];
+                    regIndex += 1;
                     return {
-                    messageId: value.message_id,
-                    regId: value.registration_id || regToken,
-                    error: value.error ? new Error(value.error) : null,
+                        messageId: value.message_id,
+                        regId: value.registration_id || regToken,
+                        error: value.error ? new Error(value.error) : null,
                     };
                 }
                 ),


### PR DESCRIPTION
I faced a problem when sending GCM Message and want to update my database to remove invalid Tokens.

I receive a response like this:
{ messageId: undefined,
  regId: undefined,
  error: Error: NotRegistered ..
}

so i replaced undefined token with regToken by order of tokens