### PR TITLE
removed blank title and message

### DIFF
--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -82,8 +82,8 @@ module.exports = (regIds, data, settings) => {
         };
     }
 
-    custom.title = custom.title || data.title || '';
-    custom.message = custom.message || data.body || '';
+    custom.title = custom.title || data.title || undefined;
+    custom.message = custom.message || data.body || undefined;
     custom.sound = custom.sound || data.sound || undefined;
     custom.icon = custom.icon || data.icon || undefined;
     custom.msgcnt = custom.msgcnt || data.badge || undefined;


### PR DESCRIPTION
This is required for sending out silent notifications. If the title or message field is present, the app treats it as a noisy notification and a blank notification is displayed.