### PR TITLE
Shut down APN client on send completion - fix memory leak

### DIFF
--- a/src/sendAPN.js
+++ b/src/sendAPN.js
@@ -64,6 +64,7 @@ module.exports = (regIds, data, settings) => {
                     });
                 }
             });
+            connection.shutdown();
             return resumed;
         });
 };

--- a/test/send/sendAPN.js
+++ b/test/send/sendAPN.js
@@ -116,6 +116,25 @@ describe('push-notifications-apn', () => {
         });
     });
 
+    describe('once notification has been sent', () => {
+        before(() => {
+            sendMethod = sendOkMethod();
+            sinon.stub(apn.Provider.prototype, 'shutdown')
+        });
+
+        after(() => {
+            sendMethod.restore();
+            apn.Provider.prototype.shutdown.restore()
+        });
+
+        it('shuts down the provider instance', (done) => {
+            pn.send(regIds, data, (err, results) => {
+                sinon.assert.calledOnce(apn.Provider.prototype.shutdown)
+                done()
+            });
+        });
+    });
+
     describe('send push notifications successfully (no payload)', () => {
         const test = (err, results, done) => {
             try {


### PR DESCRIPTION
Probably related: #47 , #44
Reopen of #54 from a different branch of the fork

The below graph is memory usage of our application, before and after applying this patch
<img width="1702" alt="screen shot 2017-06-23 at 08 43 40" src="https://user-images.githubusercontent.com/655660/27471997-a68ae8d6-57f1-11e7-9bef-91a9d62ca875.png">
