### PR TITLE
Fixed ADM regexp expression. 

### DIFF
--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -86,7 +86,7 @@ PN.prototype.send = function send(_regIds, data, callback) {
     for (const regId of regIds) {
         if (regId.substring(0, 4) === 'http') {
             regIdsWNS.push(regId);
-        } else if (/(amzn|adm)/i.test(regId)) {
+        } else if (/^(amzn[0-9]*.adm)/i.test(regId)) {
             regIdsADM.push(regId);
         } else if (regId.length > 64) {
             regIdsGCM.push(regId);

--- a/src/sendADM.js
+++ b/src/sendADM.js
@@ -2,7 +2,7 @@ const adm = require('node-adm');
 
 const method = 'adm';
 
-module.exports = (regIds, _data, settings) => {
+const sendADM = (regIds, _data, settings) => {
     const resumed = {
         method,
         success: 0,
@@ -41,3 +41,5 @@ module.exports = (regIds, _data, settings) => {
     return Promise.all(promises)
         .then(() => resumed);
 };
+
+module.exports = sendADM;

--- a/src/sendAPN.js
+++ b/src/sendAPN.js
@@ -2,7 +2,7 @@ const apn = require('apn');
 
 const method = 'apn';
 
-module.exports = (regIds, data, settings) => {
+const sendAPN = (regIds, data, settings) => {
     const message = new apn.Notification({
         retryLimit: data.retries || -1,
         expiry: data.expiry || ((data.timeToLive || 28 * 86400) + Math.floor(Date.now() / 1000)),
@@ -67,3 +67,5 @@ module.exports = (regIds, data, settings) => {
             return resumed;
         });
 };
+
+module.exports = sendAPN;

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -48,7 +48,7 @@ const sendChunk = (GCMSender, registrationTokens, message, retries) => new Promi
     });
 });
 
-module.exports = (regIds, data, settings) => {
+const sendGCM = (regIds, data, settings) => {
     const opts = Object.assign({}, settings.gcm);
     const id = opts.id;
     delete opts.id;
@@ -131,3 +131,5 @@ module.exports = (regIds, data, settings) => {
             return resumed;
         });
 };
+
+module.exports = sendGCM;

--- a/src/sendWNS.js
+++ b/src/sendWNS.js
@@ -12,8 +12,7 @@ function processResponse(err, response, regId) {
     });
 }
 
-
-module.exports = (_regIds, _data, settings) => {
+const sendWNS = (_regIds, _data, settings) => {
     // sendNotifications and sendPromises are inside exports as in this way,
     // successive calls to this module doesn't override previous ones
     let sendPromises;
@@ -80,3 +79,5 @@ module.exports = (_regIds, _data, settings) => {
     return Promise.all(promises)
         .then(() => resumed);
 };
+
+module.exports = sendWNS;

--- a/test/push-notifications/regIds.js
+++ b/test/push-notifications/regIds.js
@@ -9,6 +9,8 @@ import sendWNS from '../../src/sendWNS';
 
 const regIds = [
     'APA91bFQCD9Ndd8uVggMhj1usfeWsKIfGyBUWMprpZLGciWrMjS-77bIY24IMQNeEHzjidCcddnDxqYo-UEV03xw6ySmtIgQyzTqhSxhPGAi1maf6KDMAQGuUWc6L5Khze8YK9YrL9I_WD1gl49P3f_9hr08ZAS5Tw', // android
+    'APA9admQCD9Ndd8uVggMhj1usfeWsKIfGyBUWMprpZLGciWrMjS-77bIY24IMQNeEHzjidCcddnDxqYo-UEV03xw6ySmtIgQyzTqhSxhPGAi1maf6KDMAQGuUWc6L5Khze8YK9YrL9I_WD1gl49P3f_9hr08ZAS5Tw', // android with adm substring
+    'amzn1mQCD9Ndd8uVggMhj1usfeWsKIfGyBUWMprpZLGciWrMjS-77bIY24IMQNeEHzjidCcddnDxqYo-UEV03xw6ySmtIgQyzTqhSxhPGAi1maf6KDMAQGuUWc6L5Khze8YK9YrL9I_WD1gl49P3f_9hr08ZAS5Tw', // android with anzm start
     '43e798c31a282d129a34d84472bbdd7632562ff0732b58a85a27c5d9fdf59b69', // ios
     'https://db5.notify.windows.com/?token=AwYAAAD8sfbDrL9h7mN%2bmwlkSkQZCIfv4QKeu1hYRipj2zNvXaMi9ZAax%2f6CDfysyHp61STCO1pCFPt%2b9L4Jod72JhIcjDr8b2GxuUOBMTP%2b6%2bqxEfSB9iZfSATdZbdF7cJHSRA%3d', // windows phone
     'amzn1.adm-registration.v2.Y29tLmFtYXpvbi5EZXZpY2VNZXNzYWdpbmcuUmVnaXN0cmF0aW9uSWRFbmNyeXB0aW9uS2V5ITEhOE9rZ2h5TXlhVEFFczg2ejNWL3JMcmhTa255Uk5BclhBbE1XMFZzcnU1aFF6cTlvdU5FbVEwclZmdk5oTFBVRXVDN1luQlRSNnRVRUViREdQSlBvSzRNaXVRRUlyUy9NYWZCYS9VWTJUaGZwb3ZVTHhlRTM0MGhvampBK01hVktsMEhxakdmQStOSXRjUXBTQUhNU1NlVVVUVkFreVRhRTBCYktaQ2ZkUFdqSmIwcHgzRDhMQnllVXdxQ2EwdHNXRmFVNklYL0U4UXovcHg0K3Jjb25VbVFLRUVVOFVabnh4RDhjYmtIcHd1ZThiekorbGtzR2taMG95cC92Y3NtZytrcTRPNjhXUUpiZEk3QzFvQThBRTFWWXM2NHkyMjdYVGV5RlhhMWNHS0k9IW5GNEJMSXNleC9xbWpHSU52NnczY0E9PQ', // amazon
@@ -27,25 +29,27 @@ describe('push-notifications: call with registration ids for android, ios, windo
         pn = new PN();
         sendWith = sinon.stub(PN.prototype, 'sendWith', (method, _regIds, _data, cb) => {
             const result = {
-                method: '',
+                method: method.name,
                 success: 1,
                 failure: 0,
                 message: _regIds.map(regId => ({ regId })),
             };
             switch (regIds.indexOf(_regIds[0])) {
                 case 0:
+                case 1:
+                case 2:
                     expect(method).to.equal(sendGCM);
                     break;
 
-                case 1:
+                case 3:
                     expect(method).to.equal(sendAPN);
                     break;
 
-                case 2:
+                case 4:
                     expect(method).to.equal(sendWNS);
                     break;
 
-                case 3:
+                case 5:
                     expect(method).to.equal(sendADM);
                     break;
 
@@ -66,26 +70,39 @@ describe('push-notifications: call with registration ids for android, ios, windo
         sendWith.restore();
     });
 
+    const assertPushResults = (result, expectedNumRegIds) => {
+        if (result.method !== 'unknown') {
+            expect(result.success).to.equal(1);
+            expect(result.failure).to.equal(0);
+        } else {
+            expect(result.method).to.equal('unknown');
+            expect(result.success).to.equal(0);
+            expect(result.failure).to.equal(1);
+            expect(result.message.length).to.equal(1);
+            expect(result.message[0]).to.have.property('error');
+            expect(result.message[0].error).to.be.instanceOf(Error);
+            expect(result.message[0].error.message).to.equal('Unknown registration id');
+        }
+
+        expect(result.message.length).to.equal(expectedNumRegIds);
+        expect(result.message[0]).to.have.property('regId');
+        expect(regIds).to.include(result.message[0].regId);
+    };
+
+    const assertPushResultsForArrayInput = (result) => {
+        const expectedNumRegIds = result.method === 'sendGCM' ? 3 : 1;
+        assertPushResults(result, expectedNumRegIds);
+    };
+
+    const assertPushResultsForStringInput = (result) => {
+        assertPushResults(result, 1);
+    };
+
     it('should call the correct method for each registration id (array) and should resolve with results (callback)', (done) => {
         pn.send(regIds, data, (err, results) => {
             try {
                 expect(err).to.equal(null);
-                results.forEach((result) => {
-                    if (result.method === '') {
-                        expect(result.success).to.equal(1);
-                        expect(result.failure).to.equal(0);
-                    } else {
-                        expect(result.method).to.equal('unknown');
-                        expect(result.success).to.equal(0);
-                        expect(result.failure).to.equal(1);
-                        expect(result.message[0]).to.have.property('error');
-                        expect(result.message[0].error).to.be.instanceOf(Error);
-                        expect(result.message[0].error.message).to.equal('Unknown registration id');
-                    }
-                    expect(result.message.length).to.equal(1);
-                    expect(result.message[0]).to.have.property('regId');
-                    expect(regIds).to.include(result.message[0].regId);
-                });
+                results.forEach(assertPushResultsForArrayInput);
                 done(err);
             } catch (e) {
                 done(err || e);
@@ -96,22 +113,7 @@ describe('push-notifications: call with registration ids for android, ios, windo
     it('should call the correct method for each registration id (array) and should resolve with results (promise)', (done) => {
         pn.send(regIds, data)
             .then((results) => {
-                results.forEach((result) => {
-                    if (result.method === '') {
-                        expect(result.success).to.equal(1);
-                        expect(result.failure).to.equal(0);
-                    } else {
-                        expect(result.method).to.equal('unknown');
-                        expect(result.success).to.equal(0);
-                        expect(result.failure).to.equal(1);
-                        expect(result.message[0]).to.have.property('error');
-                        expect(result.message[0].error).to.be.instanceOf(Error);
-                        expect(result.message[0].error.message).to.equal('Unknown registration id');
-                    }
-                    expect(result.message.length).to.equal(1);
-                    expect(result.message[0]).to.have.property('regId');
-                    expect(regIds).to.include(result.message[0].regId);
-                });
+                results.forEach(assertPushResultsForArrayInput);
                 done();
             })
             .catch(done);
@@ -122,22 +124,7 @@ describe('push-notifications: call with registration ids for android, ios, windo
         regIds.forEach((regId) => {
             promises.push(pn.send(regId, data, (err, results) => {
                 expect(err).to.equal(null);
-                results.forEach((result) => {
-                    if (result.method === '') {
-                        expect(result.success).to.equal(1);
-                        expect(result.failure).to.equal(0);
-                    } else {
-                        expect(result.method).to.equal('unknown');
-                        expect(result.success).to.equal(0);
-                        expect(result.failure).to.equal(1);
-                        expect(result.message[0]).to.have.property('error');
-                        expect(result.message[0].error).to.be.instanceOf(Error);
-                        expect(result.message[0].error.message).to.equal('Unknown registration id');
-                    }
-                    expect(result.message.length).to.equal(1);
-                    expect(result.message[0]).to.have.property('regId');
-                    expect(regIds).to.include(result.message[0].regId);
-                });
+                results.forEach(assertPushResultsForStringInput);
             }));
         });
         Promise.all(promises).then(() => done(), done);
@@ -148,22 +135,7 @@ describe('push-notifications: call with registration ids for android, ios, windo
         regIds.forEach((regId) => {
             promises.push(pn.send(regId, data)
                 .then((results) => {
-                    results.forEach((result) => {
-                        if (result.method === '') {
-                            expect(result.success).to.equal(1);
-                            expect(result.failure).to.equal(0);
-                        } else {
-                            expect(result.method).to.equal('unknown');
-                            expect(result.success).to.equal(0);
-                            expect(result.failure).to.equal(1);
-                            expect(result.message[0]).to.have.property('error');
-                            expect(result.message[0].error).to.be.instanceOf(Error);
-                            expect(result.message[0].error.message).to.equal('Unknown registration id');
-                        }
-                        expect(result.message.length).to.equal(1);
-                        expect(result.message[0]).to.have.property('regId');
-                        expect(regIds).to.include(result.message[0].regId);
-                    });
+                    results.forEach(assertPushResultsForStringInput);
                 }));
         });
         Promise.all(promises).then(() => done(), done);


### PR DESCRIPTION
GCM tokens that include adm or amzn will not be recognized as ADM anymore.

Fixes https://github.com/appfeel/node-pushnotifications/issues/53