### PR TITLE
Update README to include link to integration example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ const ADMmesssage = {
 
 ## Resources
 
+- [Crossplatform integration example using this library and a React Native app](https://github.com/alex-friedl/crossplatform-push-notifications-example)
 - [Node Push Notify from alexlds](https://github.com/alexlds/node-push-notify)
 
 ## LICENSE


### PR DESCRIPTION
I included a link to my example project https://github.com/alex-friedl/crossplatform-push-notifications-example in the resources section of the README.
I developed it as a follow-up to https://github.com/appfeel/node-pushnotifications/issues/41 and hope it will help some users of the library by providing an example for a basic setup on server and client side.
