### PR TITLE
Old RegistrationIDs for GCM added in message array

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ push.send(registrationIds, data)
         failure: 0, // Number of notifications that have been failed to be send.
         message: [{
             messageId: '', // (only for android) String specifying a unique ID for each successfully processed message or undefined if error
+            originalRegId: value, // (only for android) The registrationId that was sent to the push.send() method, compare with regId to know when the original registrationId (device token id) gets changed
             regId: value, // The registrationId (device token id)
             error: new Error('unknown'), // If any, there will be an Error object here
         }],

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -27,6 +27,7 @@ const sendChunk = (GCMSender, registrationTokens, message, retries) => new Promi
                     regIndex += 1;
                     return {
                         messageId: value.message_id,
+                        oldRegId: (value.registration_id !== regToken) ? regToken : null,
                         regId: value.registration_id || regToken,
                         error: value.error ? new Error(value.error) : null,
                     };

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -11,6 +11,7 @@ const sendChunk = (GCMSender, registrationTokens, message, retries) => new Promi
                 success: 0,
                 failure: registrationTokens.length,
                 message: registrationTokens.map(value => ({
+                    originalRegId: value,
                     regId: value,
                     error: err,
                 })),
@@ -27,7 +28,7 @@ const sendChunk = (GCMSender, registrationTokens, message, retries) => new Promi
                     regIndex += 1;
                     return {
                         messageId: value.message_id,
-                        oldRegId: (value.registration_id !== regToken) ? regToken : null,
+                        originalRegId: regToken,
                         regId: value.registration_id || regToken,
                         error: value.error ? new Error(value.error) : null,
                     };
@@ -41,6 +42,7 @@ const sendChunk = (GCMSender, registrationTokens, message, retries) => new Promi
                 success: response.success,
                 failure: response.failure,
                 message: registrationTokens.map(value => ({
+                    originalRegId: value,
                     regId: value,
                     error: new Error('unknown'),
                 })),

--- a/test/send/sendGCM.js
+++ b/test/send/sendGCM.js
@@ -107,6 +107,8 @@ describe('push-notifications-gcm', () => {
                     result.message.forEach((message) => {
                         expect(message).to.have.property('regId');
                         expect(regIds).to.include(message.regId);
+                        expect(message).to.have.property('originalRegId');
+                        expect(regIds).to.include(message.originalRegId);
                     });
                 });
                 done(err);
@@ -199,6 +201,8 @@ describe('push-notifications-gcm', () => {
                     result.message.forEach((message) => {
                         expect(message).to.have.property('regId');
                         expect(regIds).to.include(message.regId);
+                        expect(message).to.have.property('originalRegId');
+                        expect(regIds).to.include(message.originalRegId);
                     });
                 });
                 done(err);
@@ -266,6 +270,8 @@ describe('push-notifications-gcm', () => {
                     result.message.forEach((message) => {
                         expect(message).to.have.property('regId');
                         expect(regIds).to.include(message.regId);
+                        expect(message).to.have.property('originalRegId');
+                        expect(regIds).to.include(message.originalRegId);
                     });
                 });
                 done(err);
@@ -381,6 +387,8 @@ describe('push-notifications-gcm', () => {
                     result.message.forEach((message) => {
                         expect(message).to.have.property('regId');
                         expect(regIds).to.include(message.regId);
+                        expect(message).to.have.property('originalRegId');
+                        expect(regIds).to.include(message.originalRegId);
                     });
                 });
                 done(err);
@@ -442,6 +450,8 @@ describe('push-notifications-gcm', () => {
                     result.message.forEach((message) => {
                         expect(message).to.have.property('regId');
                         expect(regIds).to.include(message.regId);
+                        expect(message).to.have.property('originalRegId');
+                        expect(regIds).to.include(message.originalRegId);
                     });
                 });
                 done(err);
@@ -504,6 +514,8 @@ describe('push-notifications-gcm', () => {
                     result.message.forEach((message) => {
                         expect(message).to.have.property('regId');
                         expect(regIds).to.include(message.regId);
+                        expect(message).to.have.property('originalRegId');
+                        expect(regIds).to.include(message.originalRegId);
                     });
                 });
                 done(err);
@@ -564,6 +576,8 @@ describe('push-notifications-gcm', () => {
                     result.message.forEach((message) => {
                         expect(message).to.have.property('regId');
                         expect(regIds).to.include(message.regId);
+                        expect(message).to.have.property('originalRegId');
+                        expect(regIds).to.include(message.originalRegId);
                     });
                 });
                 done(err);


### PR DESCRIPTION
In android(GCM/FCM) as everybody knows the registration IDs will be updated every now and then by google server. To keep track of it and update them in our application server we should have to read the registration_id parameter inside results array, from the response and update it to the application server accordingly. We can know what's the old registration ID and what's the updated ID by matching the index of results array with that of the index of registration IDs array which we'll send. This is possible when we send only GCM IDs but it's not possible if I send GCM with other notification service providers, as the index of the request registration ID can not be matched with the response. There should be a field inside the message object specifying the old registration ID for GCM.