### PR TITLE
Fixed usage example (production key). Resolves issue #87.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ const settings = {
             key: './certs/key.p8', // optionally: fs.readFileSync('./certs/key.p8')
             keyId: 'ABCD',
             teamId: 'EFGH',
-            production: false // true for APN production environment, false for APN sandbox environment
         },
+        production: false // true for APN production environment, false for APN sandbox environment,
         ...
     },
     adm: {


### PR DESCRIPTION
See https://github.com/node-apn/node-apn/blob/master/doc/provider.markdown for documentation of options for `apn` library.