### PR TITLE
fix: pass string to web-push library

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,11 +446,12 @@ const ADMmesssage = {
 
 ## Web-Push
 
-Data and settings are directly forwarded to `webPush.sendNotification`. 
-Data can also be a simple string payload.
+Data can be passed as a simple string payload. If you do not pass a string, it will be stringied before.
+Settings are directly forwarded to `webPush.sendNotification`. 
 
 ```js
-webPush.sendNotification(regId, data, settings.web);
+const payload = typeof data === 'string' ? data : JSON.stringify(data);
+webPush.sendNotification(regId, payload, settings.web);
 ```
 
 A working server example implementation can be found at [https://github.com/alex-friedl/webpush-example/blob/master/server/index.js](https://github.com/alex-friedl/webpush-example/blob/master/server/index.js)

--- a/src/sendWeb.js
+++ b/src/sendWeb.js
@@ -3,7 +3,8 @@ const webPush = require('web-push');
 const method = 'webPush';
 
 const sendWebPush = async (regIds, data, settings) => {
-    const promises = regIds.map(regId => (webPush.sendNotification(regId, data, settings.web)
+    const stringifiedData = typeof data === 'string' ? data : JSON.stringify(data)
+    const promises = regIds.map(regId => (webPush.sendNotification(regId, stringifiedData, settings.web)
         .then(() => ({
             success: 1,
             failure: 0,

--- a/src/sendWeb.js
+++ b/src/sendWeb.js
@@ -3,8 +3,8 @@ const webPush = require('web-push');
 const method = 'webPush';
 
 const sendWebPush = async (regIds, data, settings) => {
-    const stringifiedData = typeof data === 'string' ? data : JSON.stringify(data)
-    const promises = regIds.map(regId => (webPush.sendNotification(regId, stringifiedData, settings.web)
+    const payload = typeof data === 'string' ? data : JSON.stringify(data);
+    const promises = regIds.map(regId => (webPush.sendNotification(regId, payload, settings.web)
         .then(() => ({
             success: 1,
             failure: 0,


### PR DESCRIPTION
According to the implementation of web-push (i.e. https://github.com/web-push-libs/web-push/blob/master/src/encryption-helper.js#L33) the library expects a string instead of an object. In order to not break anything there is a check that checks beforehand if a string was already passed.