### PR TITLE
Fix body loc args property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ const data = {
     color: '', // gcm for android
     clickAction: '', // gcm for android. In ios, category will be used if not supplied
     locKey: '', // gcm, apn
-    bodyLocArgs: '', // gcm, apn
+    locArgs: '', // gcm, apn
     titleLocKey: '', // gcm, apn
     titleLocArgs: '', // gcm, apn
     retries: 1, // gcm, apn

--- a/src/sendAPN.js
+++ b/src/sendAPN.js
@@ -33,7 +33,8 @@ class APN {
                 'title-loc-key': data.titleLocKey,
                 'title-loc-args': data.titleLocArgs,
                 'loc-key': data.locKey,
-                'loc-args': data.bodyLocArgs,
+                // bodyLocArgs is kept for backward compatibility
+                'loc-args': data.locArgs || data.bodyLocArgs,
                 'launch-image': data.launchImage,
                 action: data.action,
             },


### PR DESCRIPTION
There was an inconsistency in that property naming.
Property for body loc key is named "locKey", but one for
loc args is mentioned as both "locArgs" and "bodyLocArgs"
in README, and has different names in GCM and APN senders.

For consistency sake I used "locArgs" everywhere.

I can also turn `locKey` into `bodyLocKey` if you'd like it better.