### PR TITLE
Improve FCM result processing performance

### DIFF
--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -132,7 +132,7 @@ const sendGCM = (regIds, data, settings) => {
                 }
                 resumed.success += result.success;
                 resumed.failure += result.failure;
-                resumed.message = [...resumed.message, ...result.message];
+                resumed.message.push(...result.message);
             });
 
             return resumed;


### PR DESCRIPTION
Using an immutable way of composing result array lead to
a preformance issue on large numbers of tokens.

On 1kk tokens, using `.push()` instead of `[...result, ...addend]`
decreased `forEach` execution time from ~20000ms to ~40ms
(on the same computer).