### PR TITLE
Fix inconsistent timeToLive field processing

### DIFF
--- a/src/sendAPN.js
+++ b/src/sendAPN.js
@@ -23,7 +23,7 @@ class APN {
   sendAPN(regIds, data) {
     const message = new apn.Notification({
       retryLimit: data.retries || -1,
-      expiry: data.expiry || defaultExpiry(data.timeToLive),
+      expiry: data.timeToLive || defaultExpiry(data.expiry),
       priority: data.priority === 'normal' ? 5 : 10,
       encoding: data.encoding,
       payload: data.custom || {},

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -105,12 +105,12 @@ const sendGCM = (regIds, data, settings) => {
   }
 
   const message = new gcm.Message({
-    // See https://developers.google.com/cloud-messaging/http-server-ref#table5
+    // See https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#AndroidConfig
     collapseKey: data.collapseKey,
     priority: data.priority === 'normal' ? data.priority : 'high',
     contentAvailable: data.contentAvailable || false,
     delayWhileIdle: data.delayWhileIdle || false,
-    timeToLive:
+    ttl:
       data.expiry - Math.floor(Date.now() / 1000) ||
       data.timeToLive ||
       28 * 86400,


### PR DESCRIPTION
I do not want to add any ttl and/or expiry fields (are you sure it is needed by default? It creates unnecessary notification duplicates on iOS at least) or want to add 0, but it was not possible to do consistently for APNS and GCM at the same time. With this patch it is now possible to add `timeToLive: 0` into notification object and it will add `expiry: 0` for APNS and `ttl: 0` for GCM