### PR TITLE
ADM improvements to nested payload and promise race case

### DIFF
--- a/src/sendADM.js
+++ b/src/sendADM.js
@@ -26,20 +26,23 @@ const sendADM = (regIds, _data, settings) => {
   };
 
   regIds.forEach((regId) => {
-    promises.push(new Promise((resolve) => {
-      admSender.send(message, regId, (err, response) => {
-        const errorMsg = err instanceof Error ? err.message : response.error;
-        const error = err || (response.error ? new Error(response.error) : null);
-        resumed.success += error ? 0 : 1;
-        resumed.failure += error ? 1 : 0;
-        resumed.message.push({
-          regId,
-          error,
-          errorMsg,
+    promises.push(
+      new Promise((resolve) => {
+        admSender.send(message, regId, (err, response) => {
+          const errorMsg = err instanceof Error ? err.message : response.error;
+          const error =
+            err || (response.error ? new Error(response.error) : null);
+          resumed.success += error ? 0 : 1;
+          resumed.failure += error ? 1 : 0;
+          resumed.message.push({
+            regId,
+            error,
+            errorMsg,
+          });
+          resolve();
         });
-        resolve();
-      });
-    }));
+      })
+    );
   });
 
   return Promise.all(promises).then(() => resumed);

--- a/src/sendADM.js
+++ b/src/sendADM.js
@@ -11,32 +11,35 @@ const sendADM = (regIds, _data, settings) => {
   const promises = [];
   const admSender = new adm.Sender(settings.adm);
   const data = { ..._data };
-  const { consolidationKey, expiry, timeToLive } = data;
+  const { consolidationKey, expiry, timeToLive, custom } = data;
 
   delete data.consolidationKey;
   delete data.expiry;
   delete data.timeToLive;
+  delete data.custom;
 
   const message = {
     expiresAfter:
       expiry - Math.floor(Date.now() / 1000) || timeToLive || 28 * 86400,
     consolidationKey,
-    data,
+    data: { ...data, ...custom },
   };
 
   regIds.forEach((regId) => {
-    admSender.send(message, regId, (err, response) => {
-      const errorMsg = err instanceof Error ? err.message : response.error;
-      const error = err || (response.error ? new Error(response.error) : null);
-      resumed.success += error ? 0 : 1;
-      resumed.failure += error ? 1 : 0;
-      resumed.message.push({
-        regId,
-        error,
-        errorMsg,
+    promises.push(new Promise((resolve) => {
+      admSender.send(message, regId, (err, response) => {
+        const errorMsg = err instanceof Error ? err.message : response.error;
+        const error = err || (response.error ? new Error(response.error) : null);
+        resumed.success += error ? 0 : 1;
+        resumed.failure += error ? 1 : 0;
+        resumed.message.push({
+          regId,
+          error,
+          errorMsg,
+        });
+        resolve();
       });
-      promises.push(Promise.resolve());
-    });
+    }));
   });
 
   return Promise.all(promises).then(() => resumed);

--- a/test/send/sendADM.js
+++ b/test/send/sendADM.js
@@ -57,7 +57,7 @@ function sendOkMethod() {
     expect(message.data).to.be.an('object');
     expect(message.data.title).to.eql(data.title);
     expect(message.data.body).to.eql(data.body);
-    expect(message.data.custom).to.eql(data.custom);
+    expect(message.data.sender).to.eql(data.custom.sender);
     cb(null, {});
   });
 }


### PR DESCRIPTION
Hello!

It appears that there are a couple of issues with the included ADM support. I've tried to address them in this PR!

1. From what I can figure out it looks like ADM doesn't support the full subset of parameters that this package does. One such is the `custom` key. If you include anything that goes greater than one level of nesting deep, the Amazon servers respond with a serialization error. Based on the documentation I can find it looks like everything has to be key value pairs with the value being a String (https://developer.amazon.com/docs/adm/send-message.html#message-payloads-and-uniqueness) so a nested object would not be valid. I've adjusted so that the custom payload is merged in with the rest of the `data` keys.

2. The way that the promises are structured causes the response to many times return with zero successes and zero failures. Especially if you are only sending one or two messages. This has been adjusted to wrap each callback in a promise so that it waits until all have completed before responding.

I tried to keep everything as close to your conventions as possible! Let me know if there are any issues!