### PR TITLE
obey "silent: true" setting on GCM (FCM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ const silentPushData = {
 }
 ```
 
-Internally, `silent: true` will tell `node-gcm` _not_ to send the `notification` property and only send the `custom` property. If you don't specify `silent: true` then the push notifications will still be visible on the device.
+Internally, `silent: true` will tell `node-gcm` _not_ to send the `notification` property and only send the `custom` property. If you don't specify `silent: true` then the push notifications will still be visible on the device. Note that this is essentially the same behavior as `phoneGap: true` except that it does not touch the `content-available` setting like `phoneGap`.
 
 ### Send to custom recipients (device groups or topics)
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ const data = {
         body: 'body'
         // details: https://github.com/node-apn/node-apn/blob/master/doc/notification.markdown#convenience-setters
     },
-    silent: false, // apn, will override badge, sound, alert and priority if set to true
+    silent: false, // gcm, apn, will override badge, sound, alert and priority if set to true on iOS, will omit `notification` property and send as data-only on Android/GCM
     /*
      * A string is also accepted as a payload for alert
      * Your notification won't appear on ios if alert is empty object
@@ -349,6 +349,24 @@ In that way, they can be accessed in android in the following two ways:
     String title = extras.getString("title");
     title = title != null ? title : extras.getString("gcm.notification.title");
 ```
+
+### Silent push notifications
+
+GCM supports silent push notifications which are not displayed to the user but only used to transmit data.
+
+```js
+const silentPushData = {
+    topic: 'yourTopic',
+    contentAvailable: true,
+    silent: true,
+    custom: {
+        yourKey: 'yourValue',
+        ...
+    }
+}
+```
+
+Internally, `silent: true` will tell `node-gcm` _not_ to send the `notification` property and only send the `custom` property. If you don't specify `silent: true` then the push notifications will still be visible on the device.
 
 ### Send to custom recipients (device groups or topics)
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,6 @@ GCM supports silent push notifications which are not displayed to the user but o
 ```js
 const silentPushData = {
     topic: 'yourTopic',
-    contentAvailable: true,
     silent: true,
     custom: {
         yourKey: 'yourValue',
@@ -366,7 +365,7 @@ const silentPushData = {
 }
 ```
 
-Internally, `silent: true` will tell `node-gcm` _not_ to send the `notification` property and only send the `custom` property. If you don't specify `silent: true` then the push notifications will still be visible on the device. Note that this is essentially the same behavior as `phoneGap: true` except that it does not touch the `content-available` setting like `phoneGap`.
+Internally, `silent: true` will tell `node-gcm` _not_ to send the `notification` property and only send the `custom` property. If you don't specify `silent: true` then the push notifications will still be visible on the device. Note that this is nearly the same behavior as `phoneGap: true` and will set `content-available` to `true`.
 
 ### Send to custom recipients (device groups or topics)
 

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -138,7 +138,8 @@ const sendGCM = (regIds, data, settings) => {
     restrictedPackageName: data.restrictedPackageName,
     dryRun: data.dryRun || false,
     data: opts.phonegap === true ? Object.assign(custom, notification) : custom, // See https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#android-behaviour
-    notification: opts.phonegap === true || data.silent ? undefined : notification,
+    notification:
+      opts.phonegap === true || data.silent === true ? undefined : notification,
   });
   let chunk = 0;
 

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -124,15 +124,15 @@ const sendGCM = (regIds, data, settings) => {
   custom.sound = custom.sound || data.sound;
   custom.icon = custom.icon || data.icon;
   custom.msgcnt = custom.msgcnt || data.badge;
-  if ((opts.phonegap === true || opts.silent === true) && data.contentAvailable) {
+  if (opts.phonegap === true && data.contentAvailable) {
     custom['content-available'] = 1;
   }
 
   const message = new gcm.Message({
     // See https://developers.google.com/cloud-messaging/http-server-ref#table5
     collapseKey: data.collapseKey,
-    priority: data.priority === 'normal' ? data.priority : 'high',
-    contentAvailable: data.contentAvailable || false,
+    priority: data.priority === 'normal' || data.silent ? 'normal' : 'high',
+    contentAvailable: data.silent ? true : data.contentAvailable || false,
     delayWhileIdle: data.delayWhileIdle || false,
     timeToLive: extractTimeToLive(data),
     restrictedPackageName: data.restrictedPackageName,

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -124,7 +124,7 @@ const sendGCM = (regIds, data, settings) => {
   custom.sound = custom.sound || data.sound;
   custom.icon = custom.icon || data.icon;
   custom.msgcnt = custom.msgcnt || data.badge;
-  if (opts.phonegap === true && data.contentAvailable) {
+  if ((opts.phonegap === true || opts.silent === true) && data.contentAvailable) {
     custom['content-available'] = 1;
   }
 

--- a/src/sendGCM.js
+++ b/src/sendGCM.js
@@ -138,7 +138,7 @@ const sendGCM = (regIds, data, settings) => {
     restrictedPackageName: data.restrictedPackageName,
     dryRun: data.dryRun || false,
     data: opts.phonegap === true ? Object.assign(custom, notification) : custom, // See https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#android-behaviour
-    notification: opts.phonegap === true ? undefined : notification,
+    notification: opts.phonegap === true || data.silent ? undefined : notification,
   });
   let chunk = 0;
 

--- a/test/send/sendGCM.js
+++ b/test/send/sendGCM.js
@@ -661,6 +661,7 @@ describe('push-notifications-gcm', () => {
           );
           expect(retries).to.be.a('number');
           expect(message).to.be.instanceOf(gcm.Message);
+          expect(message.params.notification).to.be.undefined();
           expect(message.params.priority).to.equal('normal');
           expect(message.params.contentAvailable).to.be.true();
           expect(message.params.data.testKey).to.eql('testValue');
@@ -688,8 +689,8 @@ describe('push-notifications-gcm', () => {
 
     it('all responses should be successful (callback, custom data undefined)', (done) => {
       const silentPushData = {
-        contentAvailable: true,
-        priority: 'normal',
+        priority: 'high',
+        silent: true,
         custom: {
           testKey: 'testValue',
         },


### PR DESCRIPTION
This fixes a bug where push notifications were showing up for display (eg on the lock screen) even though they had `silent: true` enabled and were intended to be silent, data-only notifications.